### PR TITLE
Announce plugin deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Pegdown formatter plugin - Deprecated
+
+This plugin is deprecated. It has not been released in over 10 years. It has a known [security vulnerability](https://jenkins.io/security/advisory/2019-08-07/#SECURITY-142).
+
+Instead use the [**Markdown formatter plugin**](https://plugins.jenkins.io/markdown-formatter/).


### PR DESCRIPTION
## Announce plugin deprecation

Point users to the Markdown formatter plugin that provides similar capabilities without the security vulnerability.

Part of an upcoming request to adopt the plugin in order to deprecate it.

### Testing done

Confirmed that the text looks reasonable in the pull request.  Modeled after the deprecation message on https://plugins.jenkins.io/workflow-cps-global-lib/

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
```
